### PR TITLE
fix: Use promise.all to get EventType data

### DIFF
--- a/nerdlets/nr1-event-volume-nerdlet/index.js
+++ b/nerdlets/nr1-event-volume-nerdlet/index.js
@@ -1,84 +1,108 @@
 //Nerdlet to review all data in an account
 
-import React from 'react';
-import { PlatformStateContext, NrqlQuery, Spinner, Table, TableHeader, TableHeaderCell, TableRow, TableRowCell, Stack, StackItem, JsonChart, HeadingText, BlockText, Grid, GridItem, LineChart, NerdGraphQuery } from 'nr1';
+import React from "react";
+import {
+  PlatformStateContext,
+  NrqlQuery,
+  Spinner,
+  Table,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  TableRowCell,
+  Stack,
+  StackItem,
+  JsonChart,
+  HeadingText,
+  BlockText,
+  Grid,
+  GridItem,
+  LineChart,
+  NerdGraphQuery,
+} from "nr1";
 
 // https://docs.newrelic.com/docs/new-relic-programmable-platform-introduction
 
 export default class EventVolumeNerdlet extends React.Component {
-  constructor(props){
+  constructor(props) {
     super(props);
     console.debug("Props", this); //eslint-disable-line
     this.state = {
       accountId: 734056,
-      eventVolume: null,
+      eventVolume: [],
+      loading: true,
     };
   }
-  
-  componentDidMount() {
-    this.updateData(this.props)
-  }
-    
-  updateData = props => {
-    const { accountId } = this.state;
-    
-    //console.debug("Props", props)
-    //console.debug("ID / query", accountId, nrqlQuery)
 
-    //if (accountId !== this.state.accountId) {
-      this.setState({ accountId }, () => {
-        if (accountId) {
-          //console.debug("In query")
-          // https://developer.newrelic.com/components/nrql-query
-          NrqlQuery.query({
-            accountId,
-            query: 'SHOW eventTypes'
-          })
-            .then(value => {
+  componentDidMount() {
+    this.updateData(this.props);
+  }
+
+  updateData = (props) => {
+    const { accountId } = this.state;
+
+    this.setState({ accountId }, () => {
+      if (accountId) {
+        NrqlQuery.query({
+          accountId,
+          query: "SHOW eventTypes",
+        })
+          .then((value) => {
+            const eventTypes = value.data[0].data[0].eventTypes ?? [];
+            // Create an array of NrqlQuery promises
+            const eventTypeQueries = eventTypes.map((eventType) =>
+              NrqlQuery.query({
+                accountId,
+                query: `FROM \`${eventType}\` SELECT bytecountestimate()`,
+              })
+            );
+
+            // Resolve all promises at once
+            // 'values' will be an array where each index contains the resolved response object from the query in the promise array; { data, loading, error } where loading will always be false
+            Promise.all(eventTypeQueries).then((values) => {
               const eventVolume = [];
-              value.data[0].data[0].eventTypes.forEach((item, i) => { 
-                //console.debug("Item", item)
-                NrqlQuery.query({
-                  accountId,
-                  query: `FROM \`${item}\` SELECT bytecountestimate()`
-                })
-                .then(value => {
-                  //console.debug("Value", item, value.data[0].data[0].bytecountestimate)
-                  eventVolume.push({
-                    eventType: item,
-                    bytecountestimate: value.data[0].data[0].bytecountestimate
-                  });
-                })
-                .catch(err => {
-                  console.debug("Inner Error", err, item)
-                })
+              values.forEach((value, i) => {
+                if (value.error) {
+                  console.debug("this Event type had an error", eventTypes[i]);
+                  return;
+                }
+
+                const bytecountestimate =
+                  value.data[0].data[0].bytecountestimate;
+                eventVolume.push({
+                  eventType: eventTypes[i],
+                  bytecountestimate,
+                });
               });
-              // console.debug("Inside Event Volume", eventVolume)
-              this.setState({ eventVolume })
-            })
-            .catch(err => {
-              console.debug("Outer Error", err, item)
-              //this.setState({ eventVolume: { error: err.message } });
+
+              this.setState({ eventVolume, loading: false });
             });
-        } else {
-          //console.debug("In null")
-          this.setState({ eventVolume: null });
-        }
-      });
-    //}
+          })
+          .catch((err) => {
+            console.debug("Outer Error", err, item);
+            this.setState({ loading: false });
+          });
+      } else {
+        this.setState({ loading: false });
+      }
+    });
   };
-    
-  
+
   render() {
-    console.debug("State: ", this.state)
-    const { accountId, eventVolume } = this.state;
-    //console.debug(accountId, eventVolume)
-    
-    { eventVolume && console.debug("Render Results", eventVolume) }
-    
+    const { eventVolume, loading } = this.state;
+
+    if (loading) {
+      return <Spinner />;
+    }
+
+    if (eventVolume.length === 0) {
+      // Update to use EmptyState component with error
+      return <div>Something went wrong getting event volume</div>;
+    }
+
     return (
       <div>
-        { eventVolume && <pre>{JSON.stringify(eventVolume, null, 4)}</pre> }
+        <pre>{JSON.stringify(eventVolume, null, 4)}</pre>
       </div>
     );
   }


### PR DESCRIPTION
Instead of calling non-blocking asynchronous calls inside of the forEach loop, use a promise.all(). Once you have all queries resolved, operate on the results array to build the eventVolume. 

There’s a bunch of noise from lint changes in that PR, but the key changes I made were:
1. Initialize eventVolume to an empty array in constructor. This allows us to check if its still empty after loading is finished and lets us know something has gone wrong or we couldn’t find any events.
1. Add a loading state property which is defaulted to true since we call this update function in componentDidMount. Set loading: false in state at each terminating condition.
1. Create an array of NrqlQuery promises and use Promise.all() to resolve them. Operate on the array of resolved queries. 


[Promise.all docs for reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)

UI output with this change: 
![Event_Volume_Analysis___New_Relic_One](https://user-images.githubusercontent.com/12112563/139507544-612278a1-02c5-43b9-96a3-ffad73a33d44.png)

